### PR TITLE
Cleaned up the localstorage support

### DIFF
--- a/src/components/AddExpensesDrawer/AddExpenses/AddExpenses.tsx
+++ b/src/components/AddExpensesDrawer/AddExpenses/AddExpenses.tsx
@@ -67,19 +67,6 @@ const AddExpenses = (props: AddExpensesProps) => {
   const [errorMessage, setErrorMessage] = React.useState("");
 
   /**
-   * Todo: // Clean up localstorage support once concrete solution for issue
-   * mentioned in setlocalStorage description.
-   */
-  React.useEffect(() => {
-    const { expenseItemName, expensesAmount, nextButtonCounter } = localStorage;
-    if (expenseItemName && expenseItemName && nextButtonCounter) {
-      setItemName(expenseItemName ?? "");
-      setAmount(Number(expensesAmount) ?? null);
-      setNextButtonCounter(Number(nextButtonCounter));
-    }
-  }, []);
-
-  /**
    * Function to update amount spent on an item.
    * @param event - input change event
    */
@@ -101,7 +88,6 @@ const AddExpenses = (props: AddExpensesProps) => {
    */
   const showNewCategoryModel = (): void => {
     setSelectedCategoryIndex(undefined);
-    setlocalStorage();
     props.setShowAddNewCategoryModel(true);
   };
 
@@ -116,32 +102,12 @@ const AddExpenses = (props: AddExpensesProps) => {
         return index !== categoryIndexToBeRemoved;
       }
     );
-    setlocalStorage();
     props.setExpenseCategoriesList(filteredList);
     props.setSnackbarState({
       isOpened: true,
       status: "success",
       message: "Successfully deleted the category",
     });
-  };
-
-  /**
-   * Todo: // Clean up localstorage support once concrete solution for below issue.
-   *
-   * Currently on updating props, this component is getting distroyed
-   * due to which the states are reseting to its default value i.e empty.
-   * On UI after filling itemName and amount fields and user clicks on adding new category
-   * and after user clicks back or successfully creating new category the previously entered
-   * data is lost and user need to re-enter the values again.
-   *
-   * To meticate this issue for time-being whenever the props set callback is called
-   * storing the the states values in localstorage &
-   * localstorage is cleared when expenses drawer is closed
-   */
-  const setlocalStorage = () => {
-    localStorage.setItem("expenseItemName", itemName);
-    localStorage.setItem("expensesAmount", `${amount}`);
-    localStorage.setItem("nextButtonCounter", `${nextButtonCounter}`);
   };
 
   /**

--- a/src/components/AddExpensesDrawer/AddExpensesDrawer.tsx
+++ b/src/components/AddExpensesDrawer/AddExpensesDrawer.tsx
@@ -108,7 +108,6 @@ const AddExpensesDrawer: React.FC = () => {
   const closeDrawer = (): void => {
     resetStatesToDefaultValues();
     setOpenDrawer(false);
-    localStorage.clear();
   };
 
   /**
@@ -118,80 +117,6 @@ const AddExpensesDrawer: React.FC = () => {
     setActiveButton("addExpenses");
     setDate(dayjs());
     setShowAddNewCategoryModel(false);
-  };
-
-  /**
-   * Component to show AddExpenses or AddIncome depending on which one is selected.
-   * @returns {JSX.Element}
-   */
-  const ExpenseOrIncomeComponent = () => {
-    return activeButton === "addExpenses" ? (
-      <AddExpenses
-        setShowAddNewCategoryModel={setShowAddNewCategoryModel}
-        expenseCategoriesList={expenseCategoriesList}
-        setExpenseCategoriesList={setExpenseCategoriesList}
-        setSnackbarState={setSnackbarState}
-        closeDrawer={closeDrawer}
-      />
-    ) : (
-      <AddIncome
-        incomeCategoriesList={incomeCategoriesList}
-        closeDrawer={closeDrawer}
-        setSnackbarState={setSnackbarState}
-      />
-    );
-  };
-
-  /**
-   * Component to show AddExpenses/AddIncome content when showAddNewCategoryModel is false.
-   * @returns {JSX.Element}
-   */
-  const ShowMainDrawerContent = () => {
-    return (
-      <>
-        <div className="addExpensesDrawer-drawer_top_container display-flex justify-content-space-between align-items-center">
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DemoContainer components={["DatePicker"]}>
-              <DatePicker
-                label={datePickerLabel}
-                value={date}
-                onChange={(newValue) => {
-                  newValue && handleDateChange(newValue);
-                }}
-                format="DD-MM-YYYY"
-                slotProps={{ textField: { size: "small" } }}
-                className="date-picker"
-              />
-            </DemoContainer>
-          </LocalizationProvider>
-          <HighlightOffOutlinedIcon
-            onClick={closeDrawer}
-            fontSize="large"
-            sx={{ cursor: "pointer" }}
-          />
-        </div>
-
-        <ButtonGroup className="addExpensesDrawer-add_button_group display-flex justify-content-center">
-          <Button
-            className={activeButton === "addExpenses" ? "active-button" : ""}
-            onClick={() => setActiveButton("addExpenses")}
-          >
-            Add Expenses
-          </Button>
-          <Button
-            className={activeButton === "addIncome" ? "active-button" : ""}
-            onClick={() => {
-              setActiveButton("addIncome");
-              localStorage.clear();
-            }}
-          >
-            Add Income
-          </Button>
-        </ButtonGroup>
-
-        <ExpenseOrIncomeComponent />
-      </>
-    );
   };
 
   return (
@@ -212,7 +137,11 @@ const AddExpensesDrawer: React.FC = () => {
         onClose={closeDrawer}
       >
         <div className="addExpensesDrawer-drawer_container">
-          {showAddNewCategoryModel ? (
+          <div
+            className={
+              showAddNewCategoryModel ? "display-block" : "display-none"
+            }
+          >
             <AddCategory
               setShowAddNewCategoryModel={setShowAddNewCategoryModel}
               setExpenseCategoriesList={setExpenseCategoriesList}
@@ -220,9 +149,70 @@ const AddExpensesDrawer: React.FC = () => {
               snackbarState={snackbarState}
               setSnackbarState={setSnackbarState}
             />
-          ) : (
-            <ShowMainDrawerContent />
-          )}
+          </div>
+
+          <div
+            className={
+              showAddNewCategoryModel ? "display-none" : "display-block"
+            }
+          >
+            <div className="addExpensesDrawer-drawer_top_container display-flex justify-content-space-between align-items-center">
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DemoContainer components={["DatePicker"]}>
+                  <DatePicker
+                    label={datePickerLabel}
+                    value={date}
+                    onChange={(newValue) => {
+                      newValue && handleDateChange(newValue);
+                    }}
+                    format="DD-MM-YYYY"
+                    slotProps={{ textField: { size: "small" } }}
+                    className="date-picker"
+                  />
+                </DemoContainer>
+              </LocalizationProvider>
+              <HighlightOffOutlinedIcon
+                onClick={closeDrawer}
+                fontSize="large"
+                sx={{ cursor: "pointer" }}
+              />
+            </div>
+
+            <ButtonGroup className="addExpensesDrawer-add_button_group display-flex justify-content-center">
+              <Button
+                className={
+                  activeButton === "addExpenses" ? "active-button" : ""
+                }
+                onClick={() => setActiveButton("addExpenses")}
+              >
+                Add Expenses
+              </Button>
+              <Button
+                className={activeButton === "addIncome" ? "active-button" : ""}
+                onClick={() => {
+                  setActiveButton("addIncome");
+                }}
+              >
+                Add Income
+              </Button>
+            </ButtonGroup>
+
+            {activeButton === "addExpenses" ? (
+              <AddExpenses
+                setShowAddNewCategoryModel={setShowAddNewCategoryModel}
+                expenseCategoriesList={expenseCategoriesList}
+                setExpenseCategoriesList={setExpenseCategoriesList}
+                setSnackbarState={setSnackbarState}
+                closeDrawer={closeDrawer}
+              />
+            ) : (
+              <AddIncome
+                incomeCategoriesList={incomeCategoriesList}
+                closeDrawer={closeDrawer}
+                setSnackbarState={setSnackbarState}
+              />
+            )}
+          </div>
         </div>
       </Drawer>
 


### PR DESCRIPTION
### Closes #1 

Details:
The `AddExpenses` component was getting destroyed due to the following reasons: 
1. On updating the `setShowAddNewCategoryModel,` the AddExpenses component is called depending on the value of `showAddNewCategoryModel.`
2. We have defined nested `ShowMainDrawerContent` and `ExpenseOrIncomeComponent` components in AddExpensesDrawer.

To fix the above destroying issue:
- In order to preserve the states of the AddExpenses component when the user clicks on add a new category button, instead of calling AddCategory & AddExpenses components conditionally, hide one of the components with the help of CSS properties.
- Removed both the `ShowMainDrawerContent` and `ExpenseOrIncomeComponent` nested components from the AddExpensesDrawer component.
 